### PR TITLE
Add Keyloak well known element ID

### DIFF
--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -156,6 +156,7 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                                         state={messagesPerField.existsError("username", "password") ? "error" : "default"}
                                         stateRelatedMessage={messagesPerField.getFirstError("username", "password")}
                                         nativeInputProps={{
+                                            id: "username",
                                             name: "username",
                                             autoFocus: true,
                                             autoComplete: "username",

--- a/src/login/pages/LoginConfigTotp.tsx
+++ b/src/login/pages/LoginConfigTotp.tsx
@@ -112,6 +112,7 @@ export default function LoginConfigTOTP(props: PageProps<Extract<KcContext, { pa
                         state={messagesPerField.existsError("totp") ? "error" : "default"}
                         stateRelatedMessage={messagesPerField.getFirstError("totp")}
                         nativeInputProps={{
+                            id: "totp",
                             name: "totp",
                             required: true,
                             autoFocus: true,
@@ -127,6 +128,7 @@ export default function LoginConfigTOTP(props: PageProps<Extract<KcContext, { pa
                         state={messagesPerField.existsError("userLabel") ? "error" : "default"}
                         stateRelatedMessage={messagesPerField.getFirstError("userLabel")}
                         nativeInputProps={{
+                            id: "userLabel",
                             required: (totp.otpCredentials ?? []).length > 1,
                             name: "userLabel",
                             autoFocus: true,

--- a/src/login/pages/LoginOtp.tsx
+++ b/src/login/pages/LoginOtp.tsx
@@ -75,6 +75,7 @@ export default function LoginOtp(props: PageProps<Extract<KcContext, { pageId: "
                     state={messagesPerField.existsError("totp") ? "error" : "default"}
                     stateRelatedMessage={messagesPerField.getFirstError("totp")}
                     nativeInputProps={{
+                        id: "otp",
                         name: "otp",
                         autoFocus: true,
                         autoComplete: "otp",


### PR DESCRIPTION

For E2E testing purpose we make use of ID to select elements, but it seems that certains ID are not matching with default Keycloak theme.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Iff6b7ebd86f1f10c9b27271fa936e86d6a6a6964
