### PR TITLE
fix(i18n): add missing French translations for disabled account messages

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -6,8 +6,16 @@ import type { ThemeName } from "../kc.gen";
 const { useI18n, ofTypeI18n } = i18nBuilder
     .withThemeName<ThemeName>()
     .withCustomTranslations({
-        en: { "or-login-with-email": "Or sign in with your email" },
-        fr: { "or-login-with-email": "Ou connectez-vous avec votre email" }
+       en: {
+            "or-login-with-email": "Or sign in with your email",
+            "accountTemporarilyDisabledMessage": "Invalid username or password.",
+            "accountPermanentlyDisabledMessage": "Invalid username or password."
+        },
+        fr: {
+            "or-login-with-email": "Ou connectez-vous avec votre email",
+            "accountTemporarilyDisabledMessage": "Nom d'utilisateur ou mot de passe invalide.",
+            "accountPermanentlyDisabledMessage": "Nom d'utilisateur ou mot de passe invalide."
+        }
     })
     .build();
 


### PR DESCRIPTION
Closes #34

Adds missing French translations for `accountTemporarilyDisabledMessage` 
and `accountPermanentlyDisabledMessage` in `withCustomTranslations`.

These keys were not translated, causing the error message to appear in 
English when a user's account is temporarily locked after too many failed 
login attempts.

The translations mirror the French `invalidUsernameMessage` value, 
consistent with Keycloak's default behavior of not revealing the specific 
reason for authentication failure.